### PR TITLE
Added support for NRPE checks (NRPE plugin 2.15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y -q  wget \
                     libgd2-xpm-dev \
                     libapache2-mod-php5 \
                     postfix \
+                    libssl0.9.8 \
+                    libssl-dev \
                     && rm -R /var/www/html
                     && apt-get clean \
                     && rm -rf /tmp/* /var/tmp/*  \
@@ -52,8 +54,9 @@ RUN chmod +x /etc/service/postfix/finish
 #pre-config scritp for different service that need to be run when container image is create 
 #maybe include additional software that need to be installed ... with some service running ... like example mysqld
 COPY pre-conf.sh /sbin/pre-conf
-RUN chmod +x /sbin/pre-conf \
-    && /bin/bash -c /sbin/pre-conf \
+
+RUN chmod +x /sbin/pre-conf 
+RUN /bin/bash -c /sbin/pre-conf \
     && rm /sbin/pre-conf
 
 ##scritp that can be running from the outside using docker-bash tool ...

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ to replace password :
 
 htpasswd -c /usr/local/nagios/etc/htpasswd.users nagiosadmin
 
+### Update (2015/03/19)
+Added NRPE checks support

--- a/pre-conf.sh
+++ b/pre-conf.sh
@@ -11,9 +11,11 @@
  cd /tmp
  wget http://switch.dl.sourceforge.net/project/nagios/nagios-4.x/nagios-4.1.0/nagios-4.1.0rc1.tar.gz
  wget http://nagios-plugins.org/download/nagios-plugins-2.0.3.tar.gz
+ wget http://sourceforge.net/projects/nagios/files/nrpe-2.x/nrpe-2.15/nrpe-2.15.tar.gz
  tar -xvf nagios-4.1.0rc1.tar.gz
  tar -xvf nagios-plugins-2.0.3.tar.gz
- 
+ tar -xvf nrpe-2.15.tar.gz
+
  #installing nagios
  cd /tmp/nagios-4.1.0rc1
   ./configure --with-nagios-group=nagios --with-command-group=nagcmd --with-mail=/usr/sbin/sendmail --with-httpd_conf=/etc/apache2/conf-available
@@ -36,6 +38,11 @@
   ./configure --with-nagios-user=nagios --with-nagios-group=nagios --enable-perl-modules --enable-extra-opts
   make
   make install
+
+  cd /tmp/nrpe-2.15/
+  ./configure --with-nrpe-user=nagios --with-nrpe-group=nagios --with-nagios-user=nagios --with-nagios-group=nagios  --with-ssl=/usr/bin/openssl --with-ssl-lib=/usr/lib/x86_64-linux-gnu
+  make all
+  make install-plugin
   
   #to fix error relate to ip address of container apache2
   echo "ServerName localhost" | sudo tee /etc/apache2/conf-available/fqdn.conf


### PR DESCRIPTION
Added NRPE plugin installation to support NRPE checks out of the box
Added libssl as an extra library to support NRPE installation.

Had to change the Dockerfile as the one-line command was failing for some reason (bash returned "text file busy" error)